### PR TITLE
Open up pyca/cryptography version requirement

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -862,4 +862,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "1d519d453b3507c9fd19db41ab07da47e8268b73dd76b25c016f519045b9dd0f"
+content-hash = "32fef43b1f27f503c22ba7e27c73eeae32464ae34a2fe82ddd382113cb8cee63"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-cryptography = "^41.0.3"
+cryptography = ">=41.0.3"
 requests = "^2.31.0"
 pydantic = "^2.1.1"
 


### PR DESCRIPTION
There being a new "major" version every few months it probably doesn't make sense to enforce an upper version limit.

See also https://cryptography.io/en/latest/api-stability/#versioning.