### PR TITLE
Add Poetry self-check to linting workflow

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -39,6 +39,9 @@ jobs:
       - name: Use Python ${{ matrix.py_version }} with Poetry
         run: poetry env use python${{ matrix.py_version }}
 
+      - name: Poetry self-check
+        run: poetry check
+
       - name: Install dependencies
         run: poetry install
 


### PR DESCRIPTION
Mostly to ensure that _pyproject.toml_ and _poetry.lock_ are in sync.