### PR TITLE
Install Poetry's export plugin in integration Dockerfile

### DIFF
--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -3,11 +3,12 @@
 ARG pyver=3.11
 FROM python:${pyver}-slim-bookworm AS python-prepare
 
-RUN pip install --no-cache-dir poetry
+RUN pip install --no-cache-dir poetry poetry-plugin-export
 
 WORKDIR /pip
 COPY pyproject.toml poetry.lock /pip/
 
+RUN poetry config warnings.export false
 RUN poetry export --without-hashes --format=requirements.txt --output=constraints.txt
 
 


### PR DESCRIPTION
> Warning: poetry-plugin-export will not be installed by default in a future version of Poetry.
> In order to avoid a breaking change and make your automation forward-compatible, please install poetry-plugin-export explicitly. See https://python-poetry.org/docs/plugins/#using-plugins for details on how to install a plugin.
> To disable this warning run 'poetry config warnings.export false'.