### PR TITLE
Use TypedDicts rather than nested BaseModels

### DIFF
--- a/hv4gha/gh.py
+++ b/hv4gha/gh.py
@@ -6,7 +6,7 @@ from typing import Annotated, Final, Literal
 
 import requests
 from pydantic import BaseModel, Field, TypeAdapter, ValidationError
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 
 PermARW = Literal["admin", "read", "write"]
 PermRW = Literal["read", "write"]
@@ -113,13 +113,13 @@ class AccessToken(BaseModel):
     repositories: None | list[Repository] = None
 
 
-class TokenResponse(TypedDict, total=False):
+class TokenResponse(TypedDict):
     """Typing for customized Access Token response"""
 
     access_token: str
     expires_at: datetime
     permissions: TokenPermissions
-    repositories: list[str]
+    repositories: NotRequired[list[str]]
 
 
 class GitHubApp:

--- a/integration/testrun.py
+++ b/integration/testrun.py
@@ -6,9 +6,10 @@ import sys
 from base64 import b64decode
 
 from hv4gha import TokenResponse, import_app_key, issue_access_token
+from hv4gha.gh import TokenPermissions
 
 
-def _check_perms(requested: dict[str, str], result: dict[str, str]) -> None:
+def _check_perms(requested: dict[str, str], result: TokenPermissions) -> None:
     result.pop("metadata")  # Clear default permission
     complaint = "Returned permissions does not match requested permissions"
     assert requested == result, complaint


### PR DESCRIPTION
Feels tidier when all BaseModels maps directly to an actual input and/or output.

The [typing_extensions][1] TypedDict is needed for Python < 3.12. Conveniently that package is already being installed as a Pydantic dependency.

[1]: https://pypi.org/project/typing-extensions/