### PR TITLE
Simplify API error handling

### DIFF
--- a/hv4gha/gh.py
+++ b/hv4gha/gh.py
@@ -30,14 +30,6 @@ class NotInstalledError(Exception):
     """The GitHub App isn't installed in the specified account"""
 
 
-class GitHubErrors(BaseModel):
-    """
-    https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28
-    """
-
-    message: str
-
-
 class AccountInfo(TypedDict):
     """Part of Installation"""
 
@@ -158,14 +150,7 @@ class GitHubApp:
                 )
                 response.raise_for_status()
             except requests.exceptions.HTTPError as http_error:
-                error_message = "<Failed to parse GitHub API error response>"
-                try:
-                    if http_error.response is not None:
-                        errors_bm = GitHubErrors(**http_error.response.json())
-                        error_message = errors_bm.message
-                except Exception:
-                    pass
-                raise InstallationLookupError(error_message) from http_error
+                raise InstallationLookupError(http_error.response.text) from http_error
 
             try:
                 ita = TypeAdapter(list[Installation])
@@ -225,14 +210,7 @@ class GitHubApp:
             )
             response.raise_for_status()
         except requests.exceptions.HTTPError as http_error:
-            error_message = "<Failed to parse GitHub API error response>"
-            try:
-                if http_error.response is not None:
-                    errors_bm = GitHubErrors(**http_error.response.json())
-                    error_message = errors_bm.message
-            except Exception:
-                pass
-            raise TokenIssueError(error_message) from http_error
+            raise TokenIssueError(http_error.response.text) from http_error
 
         try:
             access_token_bm = AccessToken(**response.json())

--- a/hv4gha/vault.py
+++ b/hv4gha/vault.py
@@ -94,14 +94,7 @@ class VaultTransit:
             )
             response.raise_for_status()
         except requests.exceptions.HTTPError as http_error:
-            error_message = "<Failed to parse Vault API error response>"
-            try:
-                if http_error.response is not None:
-                    errors_bm = VaultErrors(**http_error.response.json())
-                    error_message = "\n".join(errors_bm.errors)
-            except Exception:
-                pass
-            raise WrappingKeyDownloadError(error_message) from http_error
+            raise WrappingKeyDownloadError(http_error.response.text) from http_error
 
         try:
             wrapping_key_bm = WrappingKey(**response.json())
@@ -137,14 +130,7 @@ class VaultTransit:
             )
             response.raise_for_status()
         except requests.exceptions.HTTPError as http_error:
-            error_message = "<Failed to parse Vault API error response>"
-            try:
-                if http_error.response is not None:
-                    errors_bm = VaultErrors(**http_error.response.json())
-                    error_message = "\n".join(errors_bm.errors)
-            except Exception:
-                pass
-            raise vault_exception(error_message) from http_error
+            raise vault_exception(http_error.response.text) from http_error
 
         return response
 


### PR DESCRIPTION
First of all, let's skip automatically parsing all API error responses. Really isn't worth the extra code complexity just to get slightly tidier exception error messages.

With that code out of the way it makes sense to move the exception handling out of the (Vault) `__api_write` method, to where it becomes a more visible part of the application flow.