### PR TITLE
Be explicit about Python version classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,11 @@ requires-python = ">=3.10, <3.14"
 readme = "README.md"
 classifiers = [
   "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 
 [project.urls]


### PR DESCRIPTION
Apparently needed since the #42 change.