### PR TITLE
Add missing Py 3.13 tests to Integration testing workflow

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -89,3 +89,21 @@ jobs:
 
       - name: Issue scoped Access Token (Python 3.12) (unconstrained)
         run: docker compose -f integration/docker-compose.yaml run --no-deps testrun-py312-unconstrained issue-scoped
+
+      - name: Import App key (Python 3.13) (constrained)
+        run: docker compose -f integration/docker-compose.yaml run --no-deps testrun-py313-constrained import
+
+      - name: Issue Access Token (Python 3.13) (constrained)
+        run: docker compose -f integration/docker-compose.yaml run --no-deps testrun-py313-constrained issue
+
+      - name: Issue scoped Access Token (Python 3.13) (constrained)
+        run: docker compose -f integration/docker-compose.yaml run --no-deps testrun-py313-constrained issue-scoped
+
+      - name: Import App key (Python 3.13) (unconstrained)
+        run: docker compose -f integration/docker-compose.yaml run --no-deps testrun-py313-unconstrained import
+
+      - name: Issue Access Token (Python 3.13) (unconstrained)
+        run: docker compose -f integration/docker-compose.yaml run --no-deps testrun-py313-unconstrained issue
+
+      - name: Issue scoped Access Token (Python 3.13) (unconstrained)
+        run: docker compose -f integration/docker-compose.yaml run --no-deps testrun-py313-unconstrained issue-scoped


### PR DESCRIPTION
Should ideally have been a part of the #40 change.