### PR TITLE
Add integration testing for OpenBao

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -107,3 +107,18 @@ jobs:
 
       - name: Issue scoped Access Token (Python 3.13) (unconstrained)
         run: docker compose -f integration/docker-compose.yaml run --no-deps testrun-py313-unconstrained issue-scoped
+
+      - name: Bring up OpenBao server
+        run: docker compose -f integration/docker-compose.yaml up --wait --detach bao-server
+
+      - name: Configure OpenBao server
+        run: docker compose -f integration/docker-compose.yaml run --no-deps bao-setup
+
+      - name: Import App key (OpenBao) (Python 3.13) (unconstrained)
+        run: docker compose -f integration/docker-compose.yaml run --no-deps testrun-bao-py313-unconstrained import
+
+      - name: Issue Access Token (OpenBao) (Python 3.13) (unconstrained)
+        run: docker compose -f integration/docker-compose.yaml run --no-deps testrun-bao-py313-unconstrained issue
+
+      - name: Issue scoped Access Token (OpenBao) (Python 3.13) (unconstrained)
+        run: docker compose -f integration/docker-compose.yaml run --no-deps testrun-bao-py313-unconstrained issue-scoped

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Conceptually Vault here fills the role of an HSM or a Cloud KMS.
 
 See [Authenticating as a GitHub App installation (GitHub Docs)][3] for context.
 
+The library is also tested against [OpenBao][6].
+
 ## Installation
 
 ```shell
@@ -131,3 +133,4 @@ library and its [Auth Methods][5] documentation.
 [3]: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation
 [4]: https://github.com/hvac/hvac
 [5]: https://hvac.readthedocs.io/en/stable/usage/auth_methods/
+[6]: https://openbao.org/

--- a/integration/docker-compose.yaml
+++ b/integration/docker-compose.yaml
@@ -181,9 +181,32 @@ services:
     depends_on:
       - vault-setup
 
+  testrun-bao-py313-unconstrained:
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges
+    read_only: true
+    user: 3130:3130
+    build:
+      args:
+        pyver: "3.13"
+      context: ..
+      dockerfile: integration/Dockerfile
+    environment:
+      HV4GHA_KEYNAME: test-313-unconstrained
+      HV4GHA_VAULT_ADDR: http://bao-server:8200
+      HVGHA_VAULT_IMPORT_TOKEN: OpenBaoHorseImportKey
+      HVGHA_VAULT_SIGN_TOKEN: OpenBaoHorseSignJWT
+    env_file: .env
+    command: [import, issue, issue-scoped]
+    depends_on:
+      - bao-setup
+
   vault-setup:
     image: hashicorp/vault
     environment:
+      HVGHA_SETUP_COMMAND: vault
       HVGHA_VAULT_IMPORT_TOKEN: CorrectHorseImportKey
       HVGHA_VAULT_SIGN_TOKEN: CorrectHorseSignJWT
       VAULT_TOKEN: BatteryStaple
@@ -201,6 +224,33 @@ services:
     image: hashicorp/vault
     environment:
       VAULT_DEV_ROOT_TOKEN_ID: BatteryStaple
+    healthcheck:
+      test: ["CMD", "/usr/bin/nc", "-z", "127.0.0.1", "8200"]
+      interval: 1s
+      timeout: 1s
+      retries: 5
+
+  bao-setup:
+    image: openbao/openbao:latest
+    environment:
+      HVGHA_SETUP_COMMAND: bao
+      HVGHA_VAULT_IMPORT_TOKEN: OpenBaoHorseImportKey
+      HVGHA_VAULT_SIGN_TOKEN: OpenBaoHorseSignJWT
+      BAO_TOKEN: BatteryStaple
+      BAO_ADDR: http://bao-server:8200
+    volumes:
+      - ./setup:/mnt/setup
+    entrypoint: /mnt/setup
+    depends_on:
+      bao-server:
+        condition: service_healthy
+
+  bao-server:
+    cap_add:
+      - IPC_LOCK
+    image: openbao/openbao:latest
+    environment:
+      BAO_DEV_ROOT_TOKEN_ID: BatteryStaple
     healthcheck:
       test: ["CMD", "/usr/bin/nc", "-z", "127.0.0.1", "8200"]
       interval: 1s

--- a/integration/setup
+++ b/integration/setup
@@ -5,12 +5,11 @@ set -o noglob
 set -o pipefail
 
 # Required env variables
-: "$VAULT_ADDR"
-: "$VAULT_TOKEN"
+: "$HVGHA_SETUP_COMMAND"
 : "$HVGHA_VAULT_IMPORT_TOKEN"
 : "$HVGHA_VAULT_SIGN_TOKEN"
 
-vault secrets enable transit
+"$HVGHA_SETUP_COMMAND" secrets enable transit
 
 cat <<EOF |
 path "transit/wrapping_key" {
@@ -29,14 +28,14 @@ path "transit/keys/+/import_version" {
   capabilities = ["update"]
 }
 EOF
-vault policy write import-key -
+"$HVGHA_SETUP_COMMAND" policy write import-key -
 
 cat <<EOF |
 path "transit/sign/+" {
   capabilities = ["update"]
 }
 EOF
-vault policy write sign-token -
+"$HVGHA_SETUP_COMMAND" policy write sign-token -
 
-vault token create -no-default-policy -policy=import-key -id="$HVGHA_VAULT_IMPORT_TOKEN" -field=token
-vault token create -no-default-policy -policy=sign-token -id="$HVGHA_VAULT_SIGN_TOKEN" -field=token
+"$HVGHA_SETUP_COMMAND" token create -no-default-policy -policy=import-key -id="$HVGHA_VAULT_IMPORT_TOKEN" -field=token
+"$HVGHA_SETUP_COMMAND" token create -no-default-policy -policy=sign-token -id="$HVGHA_VAULT_SIGN_TOKEN" -field=token


### PR DESCRIPTION
Settled on initially only testing OpenBao against one Python build, since I don't see any potential Vault vs. OpenBao differences being Python version dependant.