### PR TITLE
Replace Super-Linter

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -61,33 +61,22 @@ jobs:
       - name: Run Pytest
         run: poetry run pytest
 
-  super:
-    name: Super-Linter
-    runs-on: ubuntu-latest
+  secondary:
+    name: Secondary linting
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
-      - name: Lint
-        uses: super-linter/super-linter/slim@v7
-        env:
-          VALIDATE_ALL_CODEBASE: true
-          VALIDATE_CHECKOV: false
-          VALIDATE_ENV: false
-          VALIDATE_GITLEAKS: false
-          VALIDATE_MARKDOWN_PRETTIER: false
-          VALIDATE_JSCPD: false
-          VALIDATE_PYTHON_BLACK: false
-          VALIDATE_PYTHON_FLAKE8: false
-          VALIDATE_PYTHON_ISORT: false
-          VALIDATE_PYTHON_MYPY: false
-          VALIDATE_PYTHON_PYINK: false
-          VALIDATE_PYTHON_PYLINT: false
-          VALIDATE_PYTHON_RUFF: false
-          VALIDATE_SHELL_SHFMT: false
-          VALIDATE_YAML_PRETTIER: false
-          DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Secondary Linters
+        uses: andreaso/setup-secondary-linters@main
+
+      - name: Lint GitHub Actions workflows
+        run: actionlint
+
+      - name: Lint integration testing Dockerfile
+        run: hadolint --ignore DL3013 integration/Dockerfile
+
+      - name: Markdown lint README
+        run: markdownlint --disable MD012 -- README.md

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -1,5 +1,3 @@
-# hadolint global ignore=DL3013
-
 ARG pyver=3.11
 FROM python:${pyver}-slim-bookworm AS python-prepare
 


### PR DESCRIPTION
The Super-Linter feels unnecessarily heavy when all the actual Python linting is done standalone and properly customized.