### PR TITLE
Fix Vault integration testing

### DIFF
--- a/integration/vault-compose.yaml
+++ b/integration/vault-compose.yaml
@@ -23,7 +23,7 @@ services:
       - vault-setup
 
   vault-setup:
-    image: hashicorp/vault
+    image: hashicorp/vault:latest
     environment:
       HVGHA_SETUP_COMMAND: vault
       HVGHA_VAULT_IMPORT_TOKEN: CorrectHorseImportKey
@@ -40,7 +40,7 @@ services:
   vault-server:
     cap_add:
       - IPC_LOCK
-    image: hashicorp/vault
+    image: hashicorp/vault:latest
     environment:
       VAULT_DEV_ROOT_TOKEN_ID: BatteryStaple
     healthcheck:

--- a/integration/vault-compose.yaml
+++ b/integration/vault-compose.yaml
@@ -42,6 +42,7 @@ services:
       - IPC_LOCK
     image: hashicorp/vault:latest
     environment:
+      SKIP_SETCAP: "true"
       VAULT_DEV_ROOT_TOKEN_ID: BatteryStaple
     healthcheck:
       test: ["CMD", "/usr/bin/nc", "-z", "127.0.0.1", "8200"]


### PR DESCRIPTION
Was broken by the `hashicorp/vault:2.0.0` image https://github.com/hashicorp/vault/issues/31919 issue.

No need to have the entrypoint script run _setcap_ when the IPC_LOCK capability is already being configured through Docker Compose.